### PR TITLE
Fix apiVersion and add selector.matchLabels for using deployments

### DIFF
--- a/kubernetes/prometheus-deployment.yaml
+++ b/kubernetes/prometheus-deployment.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-deployment
   namespace: prometheus
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-server
   template:
     metadata:
       labels:


### PR DESCRIPTION
- apiVersion should be `apps/v1`
- deployment- selector.matchLabels should be present